### PR TITLE
Fix force inline warnings on MSVC

### DIFF
--- a/include/boost/dispatch/function/make_callable.hpp
+++ b/include/boost/dispatch/function/make_callable.hpp
@@ -66,9 +66,11 @@ struct TAG : PARENT { BOOST_DISPATCH_MAKE_CALLABLE(NS,TAG,PARENT); }            
 **/
 #define BOOST_DISPATCH_FUNCTION_DECLARATION(NAMESPACE,TAG)                                          \
 template<typename... Specifications> struct impl_##TAG;                                             \
-template<typename Site>                                                                             \
-inline generic_dispatcher<NAMESPACE::TAG>                                                           \
-BOOST_DISPATCH_IMPLEMENTS(TAG, ::boost::dispatch::unspecified_<Site> const&, ... )                  \
+template<typename Site, typename... Ts>                                                             \
+BOOST_FORCEINLINE generic_dispatcher<NAMESPACE::TAG>                                                \
+BOOST_DISPATCH_IMPLEMENTS ( TAG , ::boost::dispatch::unspecified_<Site> const&                      \
+                                , ::boost::dispatch::unknown_<Ts> const&...                         \
+                          )                                                                         \
 {                                                                                                   \
   return {};                                                                                        \
 }                                                                                                   \

--- a/include/boost/dispatch/function/register_namespace.hpp
+++ b/include/boost/dispatch/function/register_namespace.hpp
@@ -112,10 +112,11 @@ namespace boost { namespace dispatch
 #define BOOST_DISPATCH_REGISTER_NAMESPACE(FALLBACK)                                                 \
 struct adl_helper {};                                                                               \
                                                                                                     \
-template<typename Tag, typename Site>                                                               \
-inline FALLBACK::generic_dispatcher<Tag>                                                            \
+template<typename Tag, typename Site, typename... Ts>                                               \
+BOOST_FORCEINLINE FALLBACK::generic_dispatcher<Tag>                                                 \
 dispatching ( adl_helper const&, ::boost::dispatch::function_<Tag> const&                           \
-            , ::boost::dispatch::unspecified_<Site> const&, ...                                     \
+            , ::boost::dispatch::unspecified_<Site> const&                                          \
+            , ::boost::dispatch::unknown_<Ts> const&...                                             \
             )                                                                                       \
 {                                                                                                   \
   return {};                                                                                        \

--- a/include/boost/dispatch/hierarchy/base.hpp
+++ b/include/boost/dispatch/hierarchy/base.hpp
@@ -18,14 +18,25 @@ namespace boost { namespace dispatch
 {
   /*!
     @ingroup group-tag
+    @brief Root hierarchy tag
+
+    The unknown_ hierarchy classify everything and is used as a top hierarchy
+  **/
+  template<typename T> struct unknown_
+  {
+    using parent        =  unknown_;
+    using hierarchy_tag =  void;
+  };
+
+  /*!
+    @ingroup group-tag
     @brief Root type hierarchy tag
 
     The type_ hierarchy classify type related informations.
   **/
-  template<typename T> struct type_
+  template<typename T> struct type_ : unknown_<T>
   {
-    using parent        =  type_;
-    using hierarchy_tag =  void;
+    using parent        =  unknown_<T>;
   };
 
   /*!
@@ -34,10 +45,9 @@ namespace boost { namespace dispatch
 
     The function_ hierarchy classify function related informations.
   **/
-  template<typename T> struct function_
+  template<typename T> struct function_ : unknown_<T>
   {
-    using parent        =  function_;
-    using hierarchy_tag =  void;
+    using parent        =  unknown_<T>;
   };
 } }
 

--- a/test/hierarchy/parent.cpp
+++ b/test/hierarchy/parent.cpp
@@ -19,8 +19,8 @@ using namespace boost::dispatch;
 
 STF_CASE( "Parenthood of base hierarchies" )
 {
-  STF_TYPE_IS( type_<void>::parent    , type_<void>     );
-  STF_TYPE_IS( function_<void>::parent, function_<void> );
+  STF_TYPE_IS( type_<void>::parent    , unknown_<void>  );
+  STF_TYPE_IS( function_<void>::parent, unknown_<void>  );
   STF_TYPE_IS( cpu_::parent           , formal_         );
 }
 


### PR DESCRIPTION
This patch reintroduce the unknwon_ hierarchy which enables us to use variadics instead of ellipsis in the catch-all cases, thus removing the warning about functions not being inlined.