### PR TITLE
Dispatched functions now respect noexcecpt specs.

### DIFF
--- a/include/boost/dispatch/function/functor.hpp
+++ b/include/boost/dispatch/function/functor.hpp
@@ -11,7 +11,12 @@
 
 #include <boost/dispatch/hierarchy/default_site.hpp>
 #include <boost/dispatch/hierarchy_of.hpp>
+#include <boost/config.hpp>
 #include <utility>
+
+#define BOOST_DISPATCH_IMPL_TAG_CALL(TAG,SITE,TS,AS)                                                \
+TAG::dispatch_to(SITE(),boost::dispatch::hierarchy_of_t<TS>()...)( std::forward<TS>(AS)...)         \
+/**/
 
 namespace boost { namespace dispatch
 {
@@ -30,14 +35,10 @@ namespace boost { namespace dispatch
     **/
     template<typename Other, typename... Args> BOOST_FORCEINLINE
     auto on(Args&&... args) const
-        -> decltype ( Tag::dispatch_to( Other()
-                                      , boost::dispatch::hierarchy_of_t<Args>()...
-                                      )( std::forward<Args>(args)...)
-                    )
+        BOOST_NOEXCEPT_IF(BOOST_NOEXCEPT_EXPR(BOOST_DISPATCH_IMPL_TAG_CALL(Tag,Other,Args,args)))
+        -> decltype (BOOST_DISPATCH_IMPL_TAG_CALL(Tag,Other,Args,args))
     {
-      return Tag::dispatch_to ( Other()
-                              , boost::dispatch::hierarchy_of_t<Args>()...
-                              )( std::forward<Args>(args)...);
+      return BOOST_DISPATCH_IMPL_TAG_CALL(Tag,Other,Args,args);
     }
 
     /*!
@@ -51,21 +52,17 @@ namespace boost { namespace dispatch
       @tparam Other New architecture target to generate a functor for
     **/
     template<typename Other>
-    static BOOST_FORCEINLINE functor<Tag,Other> rebind() { return {}; }
+    static BOOST_FORCEINLINE functor<Tag,Other> rebind() BOOST_NOEXCEPT { return {}; }
 
     /*!
 
     **/
     template<typename... Args> BOOST_FORCEINLINE
     auto operator()(Args&&... args) const
-                      -> decltype ( Tag::dispatch_to( Site()
-                                                    , boost::dispatch::hierarchy_of_t<Args>()...
-                                                    )( std::forward<Args>(args)...)
-                                  )
+        BOOST_NOEXCEPT_IF(BOOST_NOEXCEPT_EXPR(BOOST_DISPATCH_IMPL_TAG_CALL(Tag,Site,Args,args)))
+        -> decltype (BOOST_DISPATCH_IMPL_TAG_CALL(Tag,Site,Args,args))
     {
-      return Tag::dispatch_to ( Site()
-                              , boost::dispatch::hierarchy_of_t<Args>()...
-                              )( std::forward<Args>(args)...);
+      return BOOST_DISPATCH_IMPL_TAG_CALL(Tag,Site,Args,args);
     }
   };
 } }

--- a/include/boost/dispatch/function/make_callable.hpp
+++ b/include/boost/dispatch/function/make_callable.hpp
@@ -18,6 +18,7 @@
 #include <boost/dispatch/function/functor.hpp>
 #include <boost/dispatch/hierarchy/base.hpp>
 #include <boost/dispatch/detail/auto_decltype.hpp>
+#include <boost/config.hpp>
 
 /*!
   @ingroup group-function
@@ -32,7 +33,7 @@
 **/
 #define BOOST_DISPATCH_MAKE_CALLABLE(NS,TAG,PARENT)                                                 \
 template<typename... Args>                                                                          \
-static BOOST_FORCEINLINE BOOST_AUTO_DECLTYPE dispatch_to(Args&&... args)                            \
+static BOOST_FORCEINLINE BOOST_AUTO_DECLTYPE dispatch_to(Args&&... args) BOOST_NOEXCEPT             \
 BOOST_AUTO_DECLTYPE_BODY( BOOST_DISPATCH_DISPATCHING_FUNCTION(TAG)                                  \
                           (NS::adl_helper(), std::forward<Args>(args)...)                           \
                         )                                                                           \
@@ -70,7 +71,7 @@ template<typename Site, typename... Ts>                                         
 BOOST_FORCEINLINE generic_dispatcher<NAMESPACE::TAG>                                                \
 BOOST_DISPATCH_IMPLEMENTS ( TAG , ::boost::dispatch::unspecified_<Site> const&                      \
                                 , ::boost::dispatch::unknown_<Ts> const&...                         \
-                          )                                                                         \
+                          ) BOOST_NOEXCEPT                                                          \
 {                                                                                                   \
   return {};                                                                                        \
 }                                                                                                   \
@@ -102,7 +103,7 @@ static const boost::dispatch::functor<TAG> NAME = {}                            
 **/
 #define BOOST_DISPATCH_FUNCTION_DEFINITION(TAG,NAME)                                                \
 template<typename... Args> BOOST_FORCEINLINE                                                        \
-auto NAME(Args&&... args)                                                                           \
+auto NAME(Args&&... args) BOOST_NOEXCEPT                                                            \
         -> decltype ( TAG::dispatch_to( boost::dispatch::default_site<TAG>()                        \
                                       , boost::dispatch::hierarchy_of_t<Args>()...                  \
                                       )( std::forward<Args>(args)...)                               \

--- a/include/boost/dispatch/function/overload.hpp
+++ b/include/boost/dispatch/function/overload.hpp
@@ -16,6 +16,7 @@
 
 #include <boost/preprocessor/cat.hpp>
 #include <boost/preprocessor/tuple/rem.hpp>
+#include <boost/config.hpp>
 
 /*!
   @ingroup group-function
@@ -35,14 +36,15 @@ BOOST_DISPATCH_DISPATCHING_FUNCTION(TAG)( adl_helper const&, __VA_ARGS__)       
 /*!
   @ingroup group-function
 **/
-#define BOOST_DISPATCH_FALLBACK(...) dispatching( adl_helper const&, __VA_ARGS__)
+#define BOOST_DISPATCH_FALLBACK(...) dispatching( adl_helper const&, __VA_ARGS__) BOOST_NOEXCEPT
 
 /*!
   @ingroup group-function
 **/
 #define BOOST_DISPATCH_OVERLOAD(TAG, TEMPLATES, ... )                                               \
 template<BOOST_PP_TUPLE_REM_CTOR(TEMPLATES)>                                                        \
-BOOST_PP_CAT(impl_,TAG)<__VA_ARGS__> BOOST_DISPATCH_IMPLEMENTS(TAG,__VA_ARGS__) { return {}; }      \
+BOOST_PP_CAT(impl_,TAG)<__VA_ARGS__>                                                                \
+BOOST_DISPATCH_IMPLEMENTS(TAG,__VA_ARGS__) BOOST_NOEXCEPT { return {}; }                            \
 template<BOOST_PP_TUPLE_REM_CTOR(TEMPLATES)> struct BOOST_PP_CAT(impl_,TAG)<__VA_ARGS__>            \
 /**/
 
@@ -52,7 +54,8 @@ template<BOOST_PP_TUPLE_REM_CTOR(TEMPLATES)> struct BOOST_PP_CAT(impl_,TAG)<__VA
 #define BOOST_DISPATCH_OVERLOAD_FALLBACK( TEMPLATES, ... )                                          \
 template<typename... Specifications> struct impl_fallback;                                          \
 template<BOOST_PP_TUPLE_REM_CTOR(TEMPLATES)>                                                        \
-impl_fallback<__VA_ARGS__> dispatching( adl_helper const&, __VA_ARGS__) { return {}; }              \
+impl_fallback<__VA_ARGS__>                                                                          \
+dispatching( adl_helper const&, __VA_ARGS__) BOOST_NOEXCEPT { return {}; }                          \
 template<BOOST_PP_TUPLE_REM_CTOR(TEMPLATES)> struct impl_fallback<__VA_ARGS__>                      \
 /**/
 

--- a/include/boost/dispatch/function/register_namespace.hpp
+++ b/include/boost/dispatch/function/register_namespace.hpp
@@ -44,14 +44,18 @@ namespace boost { namespace dispatch
     template<typename... Call> struct no_such_overload;
 
     template<typename... Ts>
-    BOOST_FORCEINLINE no_such_overload<Tag(Site,Ts...)> operator()(Ts&& ...) const { return {}; }
+    BOOST_FORCEINLINE no_such_overload<Tag(Site,Ts...)>
+    operator()(Ts&& ...) const BOOST_NOEXCEPT { return {}; }
   };
 
   namespace meta
   {
     // The 'no luck Sherlock' case returns an incomplete type to emit an informative message
-    template<typename F, typename A>
-    inline error_<F,A> dispatching(adl_helper const&,function_<F> const&,unspecified_<A> const&,...)
+    template<typename F, typename A, typename... Ts>
+    BOOST_FORCEINLINE error_<F,A>
+    dispatching ( adl_helper const&, function_<F> const&, unspecified_<A> const&
+                , ::boost::dispatch::unknown_<Ts> const&...
+                )  BOOST_NOEXCEPT
     {
       return {};
     }
@@ -77,6 +81,11 @@ namespace boost { namespace dispatch
       template<typename... Args>
       BOOST_FORCEINLINE typename result<generic_dispatcher(Args&&...)>::type
       operator()(Args&&... args) const
+      BOOST_NOEXCEPT_IF ( BOOST_NOEXCEPT_EXPR(
+                          dispatching ( Discriminant{}, Tag{}, default_site<Tag>{}
+                                      , ::boost::dispatch::hierarchy_of_t<Args&&>()...
+                                      )( std::forward<Args>(args)... )
+                        ) )
       {
         return dispatching( Discriminant{}, Tag{}, default_site<Tag>{}
                           , ::boost::dispatch::hierarchy_of_t<Args&&>()...
@@ -86,6 +95,11 @@ namespace boost { namespace dispatch
       #else
       template<typename... Args>
       BOOST_FORCEINLINE auto operator()(Args&&... args) const
+      BOOST_NOEXCEPT_IF ( BOOST_NOEXCEPT_EXPR(
+                          dispatching ( Discriminant{}, Tag{}, default_site<Tag>{}
+                                      , ::boost::dispatch::hierarchy_of_t<Args&&>()...
+                                      )( std::forward<Args>(args)... )
+                        ) )
       BOOST_AUTO_DECLTYPE_BODY_SFINAE
       (
         dispatching ( Discriminant{}, Tag{}, default_site<Tag>{}
@@ -117,7 +131,7 @@ BOOST_FORCEINLINE FALLBACK::generic_dispatcher<Tag>                             
 dispatching ( adl_helper const&, ::boost::dispatch::function_<Tag> const&                           \
             , ::boost::dispatch::unspecified_<Site> const&                                          \
             , ::boost::dispatch::unknown_<Ts> const&...                                             \
-            )                                                                                       \
+            ) BOOST_NOEXCEPT                                                                        \
 {                                                                                                   \
   return {};                                                                                        \
 }                                                                                                   \

--- a/test/api/dispatch.cpp
+++ b/test/api/dispatch.cpp
@@ -64,3 +64,12 @@ STF_CASE( "dispatch works correctly when functor are passed as parameters")
   STF_EQUAL(some_call(tutu::titi::foo.rebind<wazoo>()), 'Z');
   STF_EQUAL(some_call(functor_type::rebind<wazoo>()),'Z');;
 }
+
+#if !defined(BOOST_NO_CXX11_NOEXCEPT)
+STF_CASE( "dispatch preserve noexcept")
+{
+  STF_EXPECT    ( BOOST_NOEXCEPT_EXPR(tutu::titi::foo('4')) );
+  STF_EXPECT_NOT( BOOST_NOEXCEPT_EXPR(tutu::titi::foo(4))   );
+  STF_EXPECT_NOT( BOOST_NOEXCEPT_EXPR(tutu::titi::foo(4.))  );
+}
+#endif

--- a/test/moc/arch/tutu/foo.hpp
+++ b/test/moc/arch/tutu/foo.hpp
@@ -10,6 +10,7 @@
 #define ARCH_TUTU_FOO_INCLUDED
 
 #include <boost/dispatch/function/overload.hpp>
+#include <boost/config.hpp>
 
 namespace tutu { namespace titi { namespace ext
 {
@@ -19,7 +20,7 @@ namespace tutu { namespace titi { namespace ext
                           , boost::dispatch::scalar_<boost::dispatch::int8_<T>>
                           )
   {
-    char operator()( T const& ) const { return '#'; }
+    char operator()( T const& ) const BOOST_NOEXCEPT{ return '#'; }
   };
 
   BOOST_DISPATCH_OVERLOAD ( foo_


### PR DESCRIPTION
If overload specify noexcept status, functor and calls to these functors respect those specifications.